### PR TITLE
Classic Sodoku

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ Cells:
 - [X] Sodoku
   - [X] Standard Grid (9x9, 3x3 subgrids)
     - [X] Classic
+    - [ ] Quadratum latinum (uses roman numerals for values)
+    - [ ] Alphabetical (uses a key of letters for values)
   - [ ] Mini Grid (6x6, 3x2 subgrids)
   - [ ] Giant Grid (16x16, 4x4 subgrids)
 - [ ] Constrainted-Based Gridded Sodoku:
   - [ ] Standard Grid (9x9, 3x3 subgrids)
+    - [ ] "Killer"
     - [ ] Greater Than
     - [ ] XV
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,22 @@
 
 ## Features
 
+Share puzzles simply by copying a string:
+
+```
+3,3,3,3,53-6---98-7-195----------6-8--4--7---6-8-3-2---3--1--6-6----------419-8-28---5-79
+```
+
+Cells:
+- Click/Tap Toggle Select
+- Drag to Select Multiple
+- Unlimited Undo Levels
+
 ### Puzzles Supported
 
-- [ ] Sodoku
-  - [ ] Standard Grid (9x9, 3x3 subgrids)
-    - [ ] Classic
+- [X] Sodoku
+  - [X] Standard Grid (9x9, 3x3 subgrids)
+    - [X] Classic
   - [ ] Mini Grid (6x6, 3x2 subgrids)
   - [ ] Giant Grid (16x16, 4x4 subgrids)
 - [ ] Constrainted-Based Gridded Sodoku:

--- a/board.go
+++ b/board.go
@@ -15,6 +15,9 @@ type board struct {
 	*fyne.Container
 	cells []*cell
 
+	// history represents cell center strings, newest at the end
+	history [][]string
+
 	boxWidth  int
 	boxHeight int
 	boxesWide int
@@ -38,6 +41,8 @@ func (b *board) check() error {
 }
 
 func (b *board) init() {
+	b.history = [][]string{}
+
 	var (
 		// TODO: support other cell arrangements, counts, in an elegant way
 		boxSize    = b.boxWidth * b.boxHeight
@@ -109,5 +114,30 @@ func (b *board) load(in string) error {
 		}
 	}
 
+	b.registerUndo()
 	return b.check()
+}
+
+func (b *board) registerUndo() {
+	state := make([]string, len(b.cells))
+
+	for i, c := range b.cells {
+		state[i] = c.center
+	}
+
+	b.history = append(b.history, state)
+}
+
+func (b *board) undo() {
+	if len(b.history) == 0 {
+		return
+	}
+
+	n := len(b.history) - 1
+	state := b.history[n]
+	b.history = b.history[:n]
+	for i, c := range b.cells {
+		c.center = state[i]
+		c.Refresh()
+	}
 }

--- a/board.go
+++ b/board.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/layout"
+	"fyne.io/fyne/widget"
+)
+
+type board struct {
+	*fyne.Container
+	cells []*cell
+
+	boxWidth  int
+	boxHeight int
+	boxesWide int
+	boxesTall int
+}
+
+func newBoard(boxWidth, boxHeight, boxesWide, boxesTall int) *board {
+	var b = &board{
+		boxWidth:  boxWidth,
+		boxHeight: boxHeight,
+		boxesWide: boxesWide,
+		boxesTall: boxesTall,
+	}
+
+	b.init()
+	return b
+}
+
+func (b *board) check() error {
+	return nil
+}
+
+func (b *board) init() {
+	var (
+		// TODO: support other cell arrangements, counts, in an elegant way
+		boxSize    = b.boxWidth * b.boxHeight
+		numBoxes   = b.boxesWide * b.boxesTall
+		boxObjects = make([]fyne.CanvasObject, numBoxes)
+	)
+
+	b.cells = make([]*cell, boxSize*numBoxes)
+
+	n := 0
+	for i := 0; i < numBoxes; i++ {
+		cells := make([]fyne.CanvasObject, boxSize)
+
+		for j := 0; j < boxSize; j++ {
+			b.cells[n] = newCell(n)
+			cells[j] = b.cells[n]
+			n++
+		}
+
+		boxObjects[i] = widget.NewCard("", "", fyne.NewContainerWithLayout(
+			layout.NewAdaptiveGridLayout(b.boxWidth),
+			cells...,
+		))
+	}
+
+	b.Container = fyne.NewContainerWithLayout(
+		layout.NewAdaptiveGridLayout(b.boxesWide),
+		boxObjects...,
+	)
+}
+
+func (b *board) load(in string) error {
+	parts := strings.Split(in, ",")
+
+	if len(parts) != 5 {
+		return errors.New("bad format")
+	}
+
+	p, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("bad boxWidth should be integer")
+	}
+	b.boxWidth = p
+
+	if p, err = strconv.Atoi(parts[1]); err != nil {
+		return fmt.Errorf("bad boxHeight should be integer")
+	}
+	b.boxHeight = p
+
+	if p, err = strconv.Atoi(parts[2]); err != nil {
+		return fmt.Errorf("bad boxesWide should be integer")
+	}
+	b.boxesWide = p
+
+	if p, err = strconv.Atoi(parts[3]); err != nil {
+		return fmt.Errorf("bad boxesTall should be integer")
+	}
+	b.boxesTall = p
+
+	b.init()
+
+	if a, b := len(parts[4]), len(b.cells); a != b {
+		return fmt.Errorf("bad data has wrong cell count: expected %d, got %d", a, b)
+	}
+
+	for i, c := range b.cells {
+		if v := parts[4][i]; v != '-' {
+			c.SetGiven(string(v))
+		}
+	}
+
+	return b.check()
+}

--- a/cell.go
+++ b/cell.go
@@ -28,6 +28,11 @@ type cell struct {
 }
 
 func newCell(id int) *cell {
+	// TODO: implement corner numbers
+	// c := fyne.NewContainerWithLayout(
+	// layout.NewAdaptiveGridLayout(3),
+	// )
+
 	c := &cell{id: id}
 	c.ExtendBaseWidget(c)
 

--- a/cell.go
+++ b/cell.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"image/color"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/driver/mobile"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+)
+
+var _ fyne.Widget = (*cell)(nil)
+var _ desktop.Hoverable = (*cell)(nil)
+var _ desktop.Mouseable = (*cell)(nil)
+var _ mobile.Touchable = (*cell)(nil)
+
+type cell struct {
+	widget.BaseWidget
+
+	center string
+	given  string
+
+	id       int
+	hovered  bool
+	selected bool
+}
+
+func newCell(id int) *cell {
+	c := &cell{id: id}
+	c.ExtendBaseWidget(c)
+
+	return c
+}
+
+func (c *cell) CreateRenderer() fyne.WidgetRenderer {
+	rend := &cellRenderer{
+		cell: c,
+		rect: canvas.NewRectangle(color.Transparent),
+		text: canvas.NewText(c.center, theme.TextColor()),
+	}
+
+	rend.rect.StrokeWidth = 1
+	rend.rect.StrokeColor = theme.ShadowColor()
+	rend.text.Alignment = fyne.TextAlignCenter
+	rend.text.TextSize = 20
+	rend.text.TextStyle.Monospace = true
+
+	return rend
+}
+
+func (c *cell) MouseIn(evt *desktop.MouseEvent) {
+	if c.given == "" {
+		c.hovered = true
+
+		if evt.Button == desktop.LeftMouseButton && downCell != c {
+			wasSelected = false // reset drag event
+			downCell = c
+			c.Select()
+			return
+		}
+
+		c.Refresh()
+	}
+}
+
+func (c *cell) MouseOut() {
+	if c.given == "" {
+		c.hovered = false
+		c.Refresh()
+	}
+}
+
+// TODO: MOVE THIS, RENAME THIS
+var downCell *cell
+var wasSelected bool
+
+func (c *cell) MouseMoved(*desktop.MouseEvent) {}
+
+func (c *cell) MouseDown(*desktop.MouseEvent) {
+	downCell = c
+	wasSelected = c.selected
+
+	if !c.selected {
+		c.Select()
+	}
+}
+
+func (c *cell) MouseUp(*desktop.MouseEvent) {
+	if downCell == c && wasSelected {
+		c.selected = false
+		c.Refresh()
+	}
+
+	downCell = nil
+	wasSelected = false
+}
+
+func (c *cell) TouchDown(*mobile.TouchEvent) {
+	c.MouseDown(nil)
+}
+
+func (c *cell) TouchUp(*mobile.TouchEvent) {
+	c.MouseUp(nil)
+}
+
+func (c *cell) TouchCancel(*mobile.TouchEvent) {}
+
+// ---
+
+func (c *cell) Select() {
+	if c.given == "" && !c.selected {
+		c.selected = true
+		c.Refresh()
+	}
+}
+
+func (c *cell) SetGiven(n string) {
+	c.given = n
+	c.Refresh()
+}
+
+func (c *cell) SetCenter(n string) {
+	c.center = n
+	c.Refresh()
+}
+
+type cellRenderer struct {
+	cell *cell
+	rect *canvas.Rectangle
+	text *canvas.Text
+}
+
+func (r *cellRenderer) BackgroundColor() color.Color {
+	return color.Transparent
+}
+
+func (r *cellRenderer) Destroy() {}
+
+func (r *cellRenderer) Layout(space fyne.Size) {
+	r.rect.Resize(space)
+
+	tSize := r.text.MinSize()
+	r.text.Move(fyne.NewPos(0, space.Height/2-tSize.Height/2))
+	r.text.Resize(fyne.NewSize(space.Width, tSize.Height))
+}
+
+func (r *cellRenderer) MinSize() fyne.Size {
+	return r.text.MinSize().Max(fyne.NewSize(48, 48))
+}
+
+func (r *cellRenderer) Objects() []fyne.CanvasObject {
+	return []fyne.CanvasObject{r.rect, r.text}
+}
+
+func (r *cellRenderer) Refresh() {
+	if r.cell.given != "" {
+		// cell is known to be correct and cannot be modified
+		r.rect.FillColor = theme.ShadowColor()
+		r.rect.StrokeColor = theme.HoverColor()
+		r.text.Text = r.cell.given
+	} else {
+		// cell is unknown and can be selected and modified
+		if r.cell.hovered {
+			r.rect.FillColor = theme.HoverColor()
+		} else if r.cell.selected {
+			r.rect.FillColor = theme.FocusColor()
+		} else {
+			r.rect.FillColor = color.Transparent
+		}
+
+		if r.cell.selected {
+			r.rect.StrokeColor = theme.FocusColor()
+		} else {
+			r.rect.StrokeColor = theme.ShadowColor()
+		}
+
+		r.text.Text = r.cell.center
+	}
+
+	r.rect.Refresh()
+	r.text.Refresh()
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"strconv"
+
 	"fyne.io/fyne"
 	"fyne.io/fyne/app"
+	"fyne.io/fyne/container"
+	"fyne.io/fyne/layout"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
 )
 
 //go:generate go run gen.go
@@ -20,5 +26,58 @@ func main() {
 }
 
 func uiInit(w fyne.Window) {
+	b := newBoard(3, 3, 3, 3)
+	b.load(`3,3,3,3,53-6---98-7-195----------6-8--4--7---6-8-3-2---3--1--6-6----------419-8-28---5-79`)
+
+	controls := make([]fyne.CanvasObject, 0)
+
+	// TODO: Support other digit systems (such as HEX for sandwiche or Giant)
+	for i := 0; i < b.boxWidth*b.boxesWide; i++ {
+		n := 1 + i
+		controls = append(controls, widget.NewButton(strconv.Itoa(n), setSelected(b, n)))
+	}
+
+	controlArea := container.NewVBox(
+		fyne.NewContainerWithLayout(
+			layout.NewAdaptiveGridLayout(b.boxWidth),
+			controls...,
+		),
+		widget.NewSeparator(),
+			widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
+				for _, c := range b.cells {
+					if c.selected {
+						c.selected = false
+						c.SetCenter("")
+					}
+				}
+			}),
+	)
+
+	w.SetContent(container.NewBorder(
+		nil, nil, nil,
+
+		// Right
+		controlArea,
+
+		// Objects
+		b.Container,
+	))
+
+	w.SetFixedSize(true)
 	w.CenterOnScreen()
+}
+
+func setSelected(b *board, n int) func() {
+	return func() {
+		b.registerUndo()
+
+		for _, c := range b.cells {
+			if c.selected {
+				c.selected = false
+				c.SetCenter(strconv.Itoa(n))
+			}
+		}
+
+		b.check()
+	}
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ func uiInit(w fyne.Window) {
 			controls...,
 		),
 		widget.NewSeparator(),
+		fyne.NewContainerWithLayout(
+			layout.NewAdaptiveGridLayout(3),
 			widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
 				for _, c := range b.cells {
 					if c.selected {
@@ -51,6 +53,8 @@ func uiInit(w fyne.Window) {
 					}
 				}
 			}),
+			widget.NewButtonWithIcon("", theme.ContentUndoIcon(), b.undo),
+		),
 	)
 
 	w.SetContent(container.NewBorder(


### PR DESCRIPTION
## Summary

Adds support for Classic 9x9 Sodoku:

Cells:
- Click/Tap Toggle Select
- Drag to Select Multiple
- Unlimited Undo Levels

## Screenshots

### Given Digits
![image](https://user-images.githubusercontent.com/1910461/104412350-e9842c80-5520-11eb-9117-d5cf793c956e.png)
### Multi-Select
![image](https://user-images.githubusercontent.com/1910461/104412938-34eb0a80-5522-11eb-98dd-5741af43a173.png)

### Details

Puzzle Format:

```
3,3,3,3,53-6---98-7-195----------6-8--4--7---6-8-3-2---3--1--6-6----------419-8-28---5-79
```

Fields are comma delimited and defined as follows:

|Name|Default|Meaning|
|-|-|-|
|BoxWidth|3|Horizontal dimension of a subgrid
|BoxHeight|3|Vertical dimension of a subgrid
|BoxesWide|3|# of subgrids horizontally per board
|BoxesTall|3|# of subgrids vertically per board
|Data|`-`|Given digits, ordered by cell within a subgrid in natural English reading order, then by subgrid. (See the image below for an example.) A hyphen `-` represents no given digit.

For the sake of illustration, the following code generates the shown grid:

```
3,3,2,1,ABCDEFGHIJKLMNOPQR
```
![image](https://user-images.githubusercontent.com/1910461/104412202-a7f38180-5520-11eb-83f7-d2178d7e4e08.png)