### PR TITLE
Consistent use of `cell.Select()` and `cell.SetMistake`

### DIFF
--- a/cmd/board.go
+++ b/cmd/board.go
@@ -54,15 +54,10 @@ type checker func(duplicates checkerCallback) error
 
 func (b *board) check() error {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 
 	var cb checkerCallback
 	if HighlightMistakes {
-		cb = func(dupes []*cell) {
-			for _, c := range dupes {
-				c.SetMistake(true)
-			}
-		}
+		cb = b.setMistakes(true)
 	}
 
 	errors := make([]error, 0)
@@ -76,11 +71,21 @@ func (b *board) check() error {
 		}
 	}
 
+	b.mu.Unlock()
+
 	if len(errors) > 0 {
 		return errors[0]
 	}
 
 	return nil
+}
+
+func (b *board) setMistakes(v bool) func([]*cell) {
+	return func(cells []*cell) {
+		for _, c := range cells {
+			c.SetMistake(v)
+		}
+	}
 }
 
 // checkSubgridRepeat checks the constraint : No value may be repeated within a subgrid
@@ -361,10 +366,7 @@ func (b *board) undo() {
 	b.history = b.history[:n]
 
 	jsoniter.Unmarshal(s.Data, &b.cells)
-	for _, c := range b.cells {
-		c.mistake = false
-		c.Refresh()
-	}
+	b.setMistakes(false)(b.cells)
 	b.mu.Unlock()
 
 	b.check()

--- a/cmd/cell.go
+++ b/cmd/cell.go
@@ -135,8 +135,10 @@ func (c *cell) SetCenter(n string) {
 }
 
 func (c *cell) SetMistake(b bool) {
-	c.mistake = b
-	c.Refresh()
+	if c.mistake != b {
+		c.mistake = b
+		c.Refresh()
+	}
 }
 
 type cellRenderer struct {

--- a/cmd/cell.go
+++ b/cmd/cell.go
@@ -88,9 +88,7 @@ func (c *cell) MouseDown(*desktop.MouseEvent) {
 	downCell = c
 	wasSelected = c.selected
 
-	if !c.selected {
-		c.Select()
-	}
+	c.Select()
 }
 
 func (c *cell) MouseUp(*desktop.MouseEvent) {


### PR DESCRIPTION
Re-organized some code to reduce external private usage of `cell.mistake` and `cell.selected`.