### PR TITLE
markdownlint - Disable Line Length Check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+engines:
+  markdownlint:
+    enabled: true
+    checks:
+      MD013:
+        enabled: false


### PR DESCRIPTION
- Adds `.codeclimate.yml` to control markdownlint options
- Disables Line Length Check in markdownlint